### PR TITLE
Fix package

### DIFF
--- a/auto-activating-snippets.el
+++ b/auto-activating-snippets.el
@@ -52,6 +52,13 @@ If any evaluate to non-nil, do not expand the snippet."
   :type 'hook
   :group 'aas)
 
+(defvar aas-keymaps (make-hash-table :test #'eq)
+  "Hash table of all snippet keymaps, in the format of symbol:keymap.")
+
+(defvar-local aas-active-keymaps nil
+  "List of symbols of the active keymaps. Each symbol should be
+present as a key in `aas-keymaps'.")
+
 (defun aas-expand-snippet-maybe (key expansion &optional condition)
   "Try to expand snippet with KEY to EXPANSION.
 
@@ -180,13 +187,6 @@ Use for the typing history, `aas--current-prefix-maps' and
                                                    (cdr kmap))
                                            #'<)))
                    aas--current-prefix-maps)))
-
-(defvar aas-keymaps (make-hash-table :test #'eq)
-  "Hash table of all snippet keymaps, in the format of symbol:keymap.")
-
-(defvar-local aas-active-keymaps nil
-  "List of symbols of the active keymaps. Each symbol should be
-present as a key in `aas-keymaps'.")
 
 ;;;###autoload
 (defun aas-activate-keymap (keymap-symbol)

--- a/auto-activating-snippets.el
+++ b/auto-activating-snippets.el
@@ -8,7 +8,7 @@
 ;; Modified: April 17, 2020
 ;; Version: 0.0.1
 ;; Homepage: https://github.com/tecosaur/auto-activating-snippets
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (dash "2.17.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'dash)
 
 (defvar aas-pre-snippet-expand-hook nil
   "Hooks to run just before expanding snippets.")


### PR DESCRIPTION
- Fix package dependency
- Fix byte-compile warnings

```
In aas-set-snippets:
auto-activating-snippets.el:112:35:Warning: reference to free variable
    ‘aas-keymaps’

In aas--format-snippet-array:
auto-activating-snippets.el:263:19:Warning: replace-regexp-in-string called
    with 2 arguments, but requires 3-7
auto-activating-snippets.el:265:19:Warning: replace-regexp-in-string called
    with 2 arguments, but requires 3-7
auto-activating-snippets.el:265:19:Warning: replace-regexp-in-string called
    with 2 arguments, but requires 3-7
auto-activating-snippets.el:265:19:Warning: ‘format’ called with 0 args to
    fill 1 format field(s)

In end of data:
auto-activating-snippets.el:277:1:Warning: the function ‘->>’ is not known to
    be defined.
```