### PR TITLE
Add require embark for aas-embark-menu

### DIFF
--- a/aas.el
+++ b/aas.el
@@ -323,6 +323,7 @@ appeared in the readme for months.")
 
 (defun aas-embark-menu ()
   (interactive)
+  (require 'embark)
   (when-let (command (embark-completing-read-prompter
                       aas--prefix-map nil 'no-default))
     (call-interactively command)))


### PR DESCRIPTION
This is so that users that lazy-load Embark do not get an error when using this command.